### PR TITLE
Update radarr docker-compose.yml typo

### DIFF
--- a/radarr/docker-compose.yml
+++ b/radarr/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         image: linuxserver/radarr
         labels:
             - "com.centurylinklabs.watchtower.enable=true"
-            - "traefik.docker.network=appstack'
+            - "traefik.docker.network=appstack"
             - "traefik.enable=true"
             - "traefik.frontend.rule=Host:${SERVER_HOST};PathPrefix: /radarr"
             - "traefik.port=7878"


### PR DESCRIPTION
A typo. Single quote following a double quote.